### PR TITLE
Add procedural tree generation

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -44,7 +44,8 @@ enum class BlockId : std::uint8_t
 {
     Air = 0,
     Grass = 1,
-    Log = 2,
+    Wood = 2,
+    Leaves = 3,
     Count
 };
 


### PR DESCRIPTION
## Summary
- add dedicated wood and leaf block IDs and atlas UV assignments
- generate deterministic trees that span chunk borders with reusable terrain sampling
- ensure trunk and canopy placement keeps leaves elevated above the ground

## Testing
- cmake -S . -B build *(fails: missing OpenGL libraries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca79f449c832188fb0d434d1403d0