### PR TITLE
Add biome-driven terrain generation with new block types

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -36,6 +36,7 @@ inline constexpr int kMaxChunkJobsPerFrame = 12;
 inline constexpr int kMaxRingsPerFrame = 1;
 inline constexpr std::size_t kUploadBudgetBytesPerFrame = 4ull * 1024ull * 1024ull;
 inline constexpr std::size_t kMinBufferSizeBytes = 4ull * 1024ull;
+inline constexpr int kBiomeSizeInChunks = 30; // Controls the width/height of each biome in chunks.
 
 float computeFarPlaneForViewDistance(int viewDistance) noexcept;
 extern float kFarPlane;
@@ -46,6 +47,8 @@ enum class BlockId : std::uint8_t
     Grass = 1,
     Wood = 2,
     Leaves = 3,
+    Sand = 4,
+    Water = 5,
     Count
 };
 


### PR DESCRIPTION
## Summary
- introduce a configurable biome size constant along with new sand and water blocks
- add modular biome definitions and biome-aware terrain generation with gated tree spawning
- map sand and water textures in the atlas for rendering support

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcb0fb5ac0832187727efd0e9cc539