### PR TITLE
Tighten biome edge blending

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -2324,8 +2324,21 @@ void ChunkManager::Impl::generateChunkBlocks(Chunk& chunk)
             {
                 return 0.0f;
             }
+
             const float normalized = 1.0f - (distance / blendRadius);
-            return smooth01(normalized);
+            float weight = smooth01(normalized);
+
+            // The easing curve above still gives neighbouring biomes a large
+            // influence several blocks away from the actual edge.  That was
+            // causing wide "strips" of a biome to bleed deep into adjacent
+            // regions.  Emphasise the falloff towards the edge so that a
+            // biome only wins dominance when we are truly hugging the
+            // boundary.  A higher-order power keeps the transition smooth
+            // while clamping the influence well within the blend radius.
+            weight *= weight;
+            weight *= weight;
+
+            return weight;
         };
 
         const float distanceLeft = static_cast<float>(localBlockX);


### PR DESCRIPTION
## Summary
- increase the falloff curve used when blending biome influence near region edges
- ensure neighbouring biomes only dominate when very close to the boundary, eliminating wide biome strips

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dccc02a2d08321bced6928c2725df2