### PR TITLE
Align chunk height with edge length

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -1477,12 +1477,12 @@ glm::vec3 ChunkManager::Impl::findSafeSpawnPosition(float worldX, float worldZ) 
 
     const int clearanceHeight = static_cast<int>(std::ceil(kPlayerHeight)) + 1;
     const int searchTop = highestSolid + clearanceHeight + 2;
-    int searchBottom = highestSolid - 64;
+    int searchBottom = highestSolid - kChunkSizeY;
     if (searchBottom > searchTop)
     {
         searchBottom = searchTop - 1;
     }
-    searchBottom = std::max(searchBottom, highestSolid - 128);
+    searchBottom = std::max(searchBottom, highestSolid - 2 * kChunkSizeY);
     searchBottom = std::max(searchBottom, -256);
 
     for (int y = searchTop; y >= searchBottom; --y)

--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -27,9 +27,9 @@ inline constexpr float kAxisCollisionEpsilon = 1e-4f;
 
 inline constexpr int kChunkEdgeLength = 16;
 inline constexpr int kChunkSizeX = kChunkEdgeLength;
-inline constexpr int kChunkSizeY = 64;
+inline constexpr int kChunkSizeY = kChunkEdgeLength;
 inline constexpr int kChunkSizeZ = kChunkEdgeLength;
-inline constexpr int kChunkBlockCount = kChunkSizeX * kChunkSizeY * kChunkSizeZ;
+inline constexpr int kChunkBlockCount = kChunkEdgeLength * kChunkEdgeLength * kChunkEdgeLength;
 inline constexpr int kAtlasTileSizePixels = 16;
 inline constexpr int kDefaultViewDistance = 4;
 inline constexpr int kExtendedViewDistance = 12;


### PR DESCRIPTION
## Summary
- align the chunk Y dimension with the configured edge length so block storage becomes cubic
- update spawn search bounds to respect the new chunk height-derived limits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd68c19aa88321a18ffa18ab465605