### PR TITLE
Implement dynamic vertical streaming heuristics

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -33,14 +33,26 @@ inline constexpr int kChunkBlockCount = kChunkEdgeLength * kChunkEdgeLength * kC
 inline constexpr int kAtlasTileSizePixels = 16;
 inline constexpr int kDefaultViewDistance = 4;
 inline constexpr int kExtendedViewDistance = 12;
-inline constexpr int kVerticalViewDistance = 2;
+struct VerticalStreamingConfig
+{
+    int minRadiusChunks{2};
+    int maxRadiusChunks{8};
+    int columnSlackChunks{1};
+    int sampleRadiusChunks{3};
+    int horizontalEvictionSlack{1};
+    int uploadBasePerColumn{2};
+    int uploadRampDivisor{2};
+    int uploadMaxPerColumn{6};
+    int maxGenerationJobsPerColumn{3};
+};
+
+inline constexpr VerticalStreamingConfig kVerticalStreamingConfig{};
 inline constexpr int kMaxChunkJobsPerFrame = 18;
 inline constexpr int kMaxRingsPerFrame = 2;
 inline constexpr std::size_t kUploadBudgetBytesPerFrame = 6ull * 1024ull * 1024ull;
 
 inline constexpr std::size_t kMinBufferSizeBytes = 4ull * 1024ull;
 inline constexpr std::size_t kChunkPoolSoftCap = 512ull;
-inline constexpr int kMaxUploadsPerColumnPerFrame = 2;
 inline constexpr std::size_t kUploadQueueScanLimit = 128ull;
 inline constexpr int kBiomeSizeInChunks = 30; // Controls the width/height of each biome in chunks.
 
@@ -95,6 +107,9 @@ struct ChunkProfilingSnapshot
     int meshedChunks{0};
     int uploadedChunks{0};
     int throttledUploads{0};
+    int deferredUploads{0};
+    int evictedChunks{0};
+    int verticalRadius{0};
 };
 
 struct Frustum


### PR DESCRIPTION
## Summary
- replace the fixed vertical view distance with a configurable streaming profile tied to terrain heuristics
- compute per-column vertical spans and job ordering based on camera position, and adjust eviction plus upload throttling to honour new per-column limits
- extend profiling/validation reporting so dynamic vertical coverage, upload deferrals, and evictions are visible during tall/low camera sweeps

## Testing
- cmake -S . -B build *(fails: missing OpenGL development libraries in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd72c966648321b3fa7bb1c07040f9