### PR TITLE
Fix column Z access in vertical radius calculation

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -2024,7 +2024,7 @@ int ChunkManager::Impl::columnRadiusFor(const glm::ivec2& column,
     int radius = std::max(verticalRadius, kVerticalStreamingConfig.minRadiusChunks);
 
     const int worldX = column.x * kChunkSizeX + kChunkSizeX / 2;
-    const int worldZ = column.z * kChunkSizeZ + kChunkSizeZ / 2;
+    const int worldZ = column.y * kChunkSizeZ + kChunkSizeZ / 2;
 
     int highest = columnManager_.highestSolidBlock(worldX, worldZ);
     if (highest == ColumnManager::kNoHeight)


### PR DESCRIPTION
## Summary
- correct the column Z coordinate access when computing world positions for streaming radius evaluation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7cd5f7dc8321be092e953911260a