### PR TITLE
Restore biome height caps independent of chunk size

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -182,11 +182,19 @@ struct BiomeDefinition
 
 constexpr std::size_t kBiomeCount = toIndex(BiomeId::Count);
 
+// The biome height ranges are expressed in absolute world Y units so that terrain
+// generation remains stable regardless of the chunk edge length. These values
+// mirror the pre-cubic-chunk tuning that produced varied hills for each biome.
+constexpr int kGrasslandsMaxSurfaceHeight = 61;
+constexpr int kForestMaxSurfaceHeight = 61;
+constexpr int kDesertMaxSurfaceHeight = 60;
+constexpr int kOceanMaxSurfaceHeight = 62;
+
 constexpr std::array<BiomeDefinition, kBiomeCount> kBiomeDefinitions{ {
-    {BiomeId::Grasslands, "Grasslands", BlockId::Grass, BlockId::Grass, false, 0.0f, 16.0f, 1.0f, 2, kChunkSizeY - 3},
-    {BiomeId::Forest, "Forest", BlockId::Grass, BlockId::Grass, true, 3.5f, 18.0f, 1.1f, 3, kChunkSizeY - 3},
-    {BiomeId::Desert, "Desert", BlockId::Sand, BlockId::Sand, false, 0.0f, 12.0f, 0.5f, 1, kChunkSizeY - 4},
-    {BiomeId::Ocean, "Ocean", BlockId::Water, BlockId::Water, false, 0.0f, 20.0f, 0.0f, 6, kChunkSizeY - 2},
+    {BiomeId::Grasslands, "Grasslands", BlockId::Grass, BlockId::Grass, false, 0.0f, 16.0f, 1.0f, 2, kGrasslandsMaxSurfaceHeight},
+    {BiomeId::Forest, "Forest", BlockId::Grass, BlockId::Grass, true, 3.5f, 18.0f, 1.1f, 3, kForestMaxSurfaceHeight},
+    {BiomeId::Desert, "Desert", BlockId::Sand, BlockId::Sand, false, 0.0f, 12.0f, 0.5f, 1, kDesertMaxSurfaceHeight},
+    {BiomeId::Ocean, "Ocean", BlockId::Water, BlockId::Water, false, 0.0f, 20.0f, 0.0f, 6, kOceanMaxSurfaceHeight},
 } };
 
 struct ColumnSample


### PR DESCRIPTION
## Summary
- decouple biome surface height caps from chunk edge length so cubic chunks retain the legacy hill variance
- document that biome height ranges are expressed in world coordinates to keep terrain shaping stable across chunk configurations

## Testing
- not run (explanation: no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68dd92aeb5f88321937309e5cbc6c768