### PR TITLE
Implement adaptive chunk upload budgeting

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -134,6 +134,9 @@ struct ChunkProfilingSnapshot
     int generationColumnCap{0};
     int generationBacklogSteps{0};
     int workerThreads{0};
+    std::size_t uploadBudgetBytes{0};
+    int uploadColumnLimit{0};
+    int pendingUploadChunks{0};
 };
 
 struct Frustum


### PR DESCRIPTION
## Summary
- add adaptive chunk upload budgeting that scales GPU upload throughput when the queue backs up or headroom remains
- allow burst uploads per column using the adaptive limits and track actual bytes consumed each frame
- expose upload budgeting metrics through `ChunkProfilingSnapshot` for easier profiling of the new behaviour

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df1e35a230832180150fd6a999a539