### PR TITLE
Add F3 LOD toggle with surface-only far chunk path

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -179,6 +179,8 @@ public:
     void toggleViewDistance();
     int viewDistance() const noexcept;
     void setRenderDistance(int distance) noexcept;
+    void setLodEnabled(bool enabled);
+    bool lodEnabled() const noexcept;
 
     BlockId blockAt(const glm::ivec3& worldPos) const noexcept;
     glm::vec3 findSafeSpawnPosition(float worldX, float worldZ) const;

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -23,6 +23,9 @@ struct InputContext
     bool nKeyJustPressed{false};
     bool f1Pressed{false};
     bool f1JustPressed{false};
+    bool f3Pressed{false};
+    bool f3JustPressed{false};
+    bool lodEnabled{false};
     bool showCoordinates{false};
     bool showRenderDistanceGUI{false};
     std::string inputBuffer{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -809,6 +809,16 @@ void main()
         inputContext.f1JustPressed = f1JustPressed;
         inputContext.f1Pressed = f1CurrentlyPressed;
 
+        bool f3CurrentlyPressed = (glfwGetKey(window, GLFW_KEY_F3) == GLFW_PRESS);
+        bool f3JustPressed = f3CurrentlyPressed && !inputContext.f3Pressed;
+        if (f3JustPressed)
+        {
+            inputContext.lodEnabled = !inputContext.lodEnabled;
+            chunkManager.setLodEnabled(inputContext.lodEnabled);
+        }
+        inputContext.f3JustPressed = f3JustPressed;
+        inputContext.f3Pressed = f3CurrentlyPressed;
+
         // Only close window with ESC if GUI is not active
         // (ESC to close GUI is handled in computePlayerInputState)
         if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS && !inputContext.showRenderDistanceGUI)


### PR DESCRIPTION
## Summary
- add F3 input handling to toggle the chunk manager's new surface-only LOD mode
- extend the chunk manager with FarChunk metadata, surface generation, and streaming logic that branches when LOD is enabled
- build lightweight surface meshes and expose a setLodEnabled API so the mode can be switched at runtime

## Testing
- not run (MSVC-only build system not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68df2a73bcd083219d963762456788ea