### PR TITLE
Fix Perlin gradient normalization for terrain noise

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -1092,7 +1092,7 @@ float PerlinNoise::grad(int hash, float x, float y) noexcept
     const int h = hash & 7;
     const float u = h < 4 ? x : y;
     const float v = h < 4 ? y : x;
-    return ((h & 1) ? -u : u) + ((h & 2) ? -2.0f * v : 2.0f * v);
+    return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
 }
 
 // ChunkManager::Impl methods (to be filled)


### PR DESCRIPTION
## Summary
- update the PerlinNoise gradient helper to remove the doubled axis scaling that warped noise amplitudes
- restore balanced 2D noise so terrain basis sampling produces natural-looking surfaces

## Testing
- not run (Windows-only build script is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df522172e48321b4a0f6656f8a375c