### PR TITLE
Fix tree structure placement across chunks

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -4257,12 +4257,6 @@ void ChunkManager::Impl::generateChunkBlocks(Chunk& chunk)
 
         auto setOrQueueBlock = [&](int worldX, int worldY, int worldZ, BlockId block, bool replaceSolid)
         {
-            if (worldX < baseWorldX || worldX >= baseWorldX + kChunkSizeX ||
-                worldZ < baseWorldZ || worldZ >= baseWorldZ + kChunkSizeZ)
-            {
-                return;
-            }
-
             const glm::ivec3 worldPos{worldX, worldY, worldZ};
             const glm::ivec3 targetChunk = worldToChunkCoords(worldX, worldY, worldZ);
             if (targetChunk == chunk.coord)
@@ -4288,6 +4282,11 @@ void ChunkManager::Impl::generateChunkBlocks(Chunk& chunk)
             }
             else
             {
+                if (block == BlockId::Air)
+                {
+                    return;
+                }
+
                 externalEdits.push_back(PendingStructureEdit{targetChunk, worldPos, block, replaceSolid});
             }
         };


### PR DESCRIPTION
## Summary
- allow tree generation to enqueue blocks that land in neighboring chunks
- prevent queuing empty edits when targeting other chunks

## Testing
- not run (Windows-only build script)

------
https://chatgpt.com/codex/tasks/task_e_68df553bae4c83219cc09169f06ba423