### PR TITLE
Restrict shoreline sand placement to mixed biomes

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -4024,7 +4024,18 @@ ColumnSample ChunkManager::Impl::sampleColumn(int worldX, int worldZ, int slabMi
         }
     }
 
-    float distanceToShore = shorelineDistance;
+    float distanceToShore = std::numeric_limits<float>::infinity();
+
+    if (hasOceanContribution && hasLandContribution)
+    {
+        distanceToShore = shorelineDistance;
+        if (shorelineBlend > std::numeric_limits<float>::epsilon())
+        {
+            const float blendScale = std::clamp(shorelineBlend, 0.0f, 1.0f);
+            // Areas with stronger ocean/land mixing should be considered closer to the coast.
+            distanceToShore /= std::max(blendScale, 0.0001f);
+        }
+    }
 
     if (perturbations.dominantBiome && perturbations.dominantBiome->id == BiomeId::Ocean && hasOceanContribution)
     {


### PR DESCRIPTION
## Summary
- prevent beach decoration from triggering in biomes without both land and ocean contributions
- scale shoreline distance by blend strength so only true coasts receive sand/grass swaps

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df66f77e348321b442d9be0ccff7df