### PR TITLE
Add stone block entry to the atlas

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -1195,6 +1195,11 @@ void ChunkManager::Impl::setBlockTextureAtlasConfig(const glm::ivec2& textureSiz
         assignFace(BlockId::Water, face, {0, 7});
     }
 
+    for (BlockFace face : {BlockFace::Top, BlockFace::Bottom, BlockFace::North, BlockFace::South, BlockFace::East, BlockFace::West})
+    {
+        assignFace(BlockId::Stone, face, {1, 9});
+    }
+
     blockAtlasConfigured_ = true;
 }
 

--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -83,6 +83,7 @@ enum class BlockId : std::uint8_t
     Leaves = 3,
     Sand = 4,
     Water = 5,
+    Stone = 6,
     Count
 };
 


### PR DESCRIPTION
## Summary
- add the Stone block to the BlockId enumeration for future use
- map the Stone block's faces to column 1, row 9 of the atlas texture

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df78ae6060832188d1f6f0a7bee401