### PR TITLE
Implement vertical streaming falloff for distant columns

### DIFF
--- a/src/chunk_manager.h
+++ b/src/chunk_manager.h
@@ -45,6 +45,7 @@ struct VerticalStreamingConfig
     int uploadMaxPerColumn{24};
     int maxGenerationJobsPerColumn{12};
     int backlogColumnCapReleaseThreshold{4096};
+    int verticalRadiusFalloffStep{8};
 
     struct GenerationBudgetSettings
     {


### PR DESCRIPTION
## Summary
- add a configurable vertical radius falloff to the vertical streaming settings
- compute per-column vertical radii using camera-aware distance falloff while preserving height coverage
- update streaming maintenance routines to respect the new per-column radii when estimating work and evicting chunks

## Testing
- not run (Windows-only build pipeline)


------
https://chatgpt.com/codex/tasks/task_e_68df8caf1fc48321a4526660adc02205