### PR TITLE
Soften Little Mountains slopes and lower base height

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -202,7 +202,7 @@ constexpr std::size_t kBiomeCount = toIndex(BiomeId::Count);
 constexpr int kGrasslandsMaxSurfaceHeight = 61;
 constexpr int kForestMaxSurfaceHeight = 61;
 constexpr int kDesertMaxSurfaceHeight = 60;
-constexpr int kLittleMountainsMinSurfaceHeight = 480;
+constexpr int kLittleMountainsMinSurfaceHeight = 30;
 constexpr int kLittleMountainsMaxSurfaceHeight = 820;
 constexpr int kGlobalSeaLevel = 20;
 constexpr int kOceanMaxSurfaceHeight = kGlobalSeaLevel;
@@ -4114,8 +4114,14 @@ float ChunkManager::Impl::computeLittleMountainsHeight(int worldX,
     float baseHeight = minHeight + normalized * range;
 
     const float sampleStep = 12.0f;
-    const float talusAngle = glm::radians(33.0f);
-    const float maxDiff = std::tan(talusAngle) * sampleStep;
+    const float gentleTalusAngle = glm::radians(9.0f);
+    const float upperTalusAngle = glm::radians(14.0f);
+    const float gentleMaxDiff = std::tan(gentleTalusAngle) * sampleStep;
+    const float upperMaxDiff = std::tan(upperTalusAngle) * sampleStep;
+    const float highSlopeStart = minHeight + range * 0.65f;
+    const float highSlopeEnd = minHeight + range * 0.90f;
+    const float altitudeT = std::clamp((baseHeight - highSlopeStart) / (highSlopeEnd - highSlopeStart), 0.0f, 1.0f);
+    const float maxDiff = std::lerp(gentleMaxDiff, upperMaxDiff, altitudeT);
 
     auto sampleNeighbor = [&](float offsetX, float offsetZ) {
         const float neighborNormalized =
@@ -4145,7 +4151,7 @@ float ChunkManager::Impl::computeLittleMountainsHeight(int worldX,
         }
     }
 
-    baseHeight = std::lerp(baseHeight, relaxedHeight, 0.6f);
+    baseHeight = std::lerp(baseHeight, relaxedHeight, 0.8f);
 
     return std::clamp(baseHeight, minHeight, maxHeight);
 }


### PR DESCRIPTION
## Summary
- drop the Little Mountains biome minimum surface height to 30 so the biome can blend into much lower terrain
- tighten the talus relaxation so typical slopes only climb 1-2 blocks per 12-block step, reserving ~3-block rises for high ridges
- increase the lerp toward the relaxed surface so the gentle slope limit actually shapes the final terrain sample

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e007c3c6a0832193fe4233fd304c39