### PR TITLE
Increase Little Mountains biome footprint

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -262,7 +262,7 @@ constexpr std::array<BiomeDefinition, kBiomeCount> kBiomeDefinitions{ {
      kLittleMountainsMaxSurfaceHeight,
      0.1f,
      320.0f,
-     1.6f},
+     2.4f},
     {BiomeId::Ocean,
      "Ocean",
      BlockId::Water,


### PR DESCRIPTION
## Summary
- increase the Little Mountains biome footprint multiplier from 1.6 to 2.4 to broaden its coverage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04eb568108321bce6c970e1301f1d