### PR TITLE
Prioritize normalized distances when selecting biome candidates

### DIFF
--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -4867,6 +4867,22 @@ ColumnSample ChunkManager::Impl::sampleColumn(int worldX, int worldZ, int slabMi
                           candidateSites.begin() + candidateCount,
                           [](const CandidateSite& lhs, const CandidateSite& rhs)
                           {
+                              const bool lhsValid = std::isfinite(lhs.normalizedDistance);
+                              const bool rhsValid = std::isfinite(rhs.normalizedDistance);
+                              if (lhsValid && rhsValid)
+                              {
+                                  if (lhs.normalizedDistance == rhs.normalizedDistance)
+                                  {
+                                      return lhs.distanceSquared < rhs.distanceSquared;
+                                  }
+                                  return lhs.normalizedDistance < rhs.normalizedDistance;
+                              }
+
+                              if (lhsValid != rhsValid)
+                              {
+                                  return lhsValid;
+                              }
+
                               return lhs.distanceSquared < rhs.distanceSquared;
                           });
     }


### PR DESCRIPTION
## Summary
- update the candidate biome partial sort to rank by normalized distance, with a fallback to squared distance
- ensure large biome footprints such as Little Mountains remain eligible for weighting

## Testing
- `./build_blockgame.bat debug` *(fails: Windows batch script cannot run in this Linux container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0981f07048321896c796b8e641521