### PR TITLE
Gate coastal sub-biome spawning on nearby ocean seeds

### DIFF
--- a/src/terrain/climate_map.cpp
+++ b/src/terrain/climate_map.cpp
@@ -721,6 +721,34 @@ void NoiseVoronoiClimateGenerator::spawnSubBiomeSeeds(const BiomeSeed& parent,
         float radius = sub.sampleRadius(parentRadius * 0.75f, radiusNoise);
         radius = std::clamp(radius, 4.0f, parentRadius);
 
+        const bool requiresOceanNeighbor =
+            sub.biome->generationProperties().isCoastal() || sub.biome->hasFlag("beach");
+        if (requiresOceanNeighbor)
+        {
+            constexpr float kOceanProximityFactor = 2.0f;
+            bool hasNearbyOcean = false;
+            for (const BiomeSeed& oceanSeed : seeds)
+            {
+                if (!oceanSeed.biome || !oceanSeed.biome->isOcean())
+                {
+                    continue;
+                }
+
+                const float distanceToOcean =
+                    glm::length(glm::vec2(candidatePos - oceanSeed.position));
+                if (distanceToOcean <= radius * kOceanProximityFactor)
+                {
+                    hasNearbyOcean = true;
+                    break;
+                }
+            }
+
+            if (!hasNearbyOcean)
+            {
+                continue;
+            }
+        }
+
         if (!isValidPlacement(candidatePos, radius, seeds))
         {
             continue;


### PR DESCRIPTION
## Summary
- require coastal and beach sub-biomes to only spawn when an ocean seed is within a small multiple of their radius
- skip spawning those sub-biomes when no nearby ocean seeds exist to prevent inland placement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3d17a8bc08321b4dbcb2b62b68737